### PR TITLE
feat: 新增路由、撰寫首頁與登入頁路由

### DIFF
--- a/src/Routes/index.jsx
+++ b/src/Routes/index.jsx
@@ -1,0 +1,25 @@
+import { createHashRouter } from "react-router";
+
+import Front from "../layout/Front";
+import Home from "../pages/Home";
+import Login from "../pages/Login";
+
+const routes = [
+  {
+    path: "/",
+    element: <Front />,
+    children: [
+      {
+        index: true,
+        element: <Home />,
+      },
+    ],
+  },
+  {
+    path: "/login",
+    element: <Login />,
+  },
+];
+
+const router = createHashRouter(routes);
+export default router;

--- a/src/layout/Front.jsx
+++ b/src/layout/Front.jsx
@@ -1,0 +1,7 @@
+import { Outlet } from "react-router";
+
+const Front = () => {
+  return <Outlet />;
+};
+
+export default Front;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,12 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import '../assets/scss/all.scss'
-import App from './App.jsx'
-
-createRoot(document.getElementById('root')).render(
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { RouterProvider } from "react-router";
+import router from "./Routes";
+import "../assets/scss/all.scss";
+// import App from './App.jsx'
+createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    {/* <App /> */}
+    <RouterProvider router={router} />
+  </StrictMode>
+);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,5 @@
+const Home = () => {
+  return <div>這是首頁</div>;
+};
+
+export default Home;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,5 @@
+const Login = () => {
+  return <div>這裡是登入頁面</div>;
+};
+
+export default Login;


### PR DESCRIPTION
新增一個前台Layout模板
後續大家可以在Routes/index.jsx 的routes 新增路由物件試試
前台頁面可以寫在children內 
ex :  {path:'allPost' , element: < AllPost />}
後台頁面交給 墨吧(?