### PR TITLE
update accountSetting route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dayjs": "^1.11.13",
         "gh-pages": "^6.3.0",
         "gsap": "^3.12.7",
+        "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-datepicker": "^8.1.0",
         "react-dom": "^18.3.1",
@@ -3940,6 +3941,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dayjs": "^1.11.13",
     "gh-pages": "^6.3.0",
     "gsap": "^3.12.7",
+    "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-datepicker": "^8.1.0",
     "react-dom": "^18.3.1",

--- a/src/Routes/index.jsx
+++ b/src/Routes/index.jsx
@@ -48,7 +48,7 @@ const routes = [
         element: <Account />,
         children: [
           {
-            index: true,
+            path: 'setting',
             element: <AccountSetting />,
           },
           {

--- a/src/components/ShareFoodModal.jsx
+++ b/src/components/ShareFoodModal.jsx
@@ -15,21 +15,24 @@ const ShareFoodModal = () => {
   const [startDate, setStartDate] = useState(null);
   const methods = useForm({
     defaultValues: {
-      InputTitle: '',
-      InputFood: '',
-      FoodType: '',
-      SaveMethod: '',
-      FoodNum: '',
-      exp: '',
-      city: '',
-      district: '',
-      overfood: '',
-      MeatOrVeggie: '',
-      pickUpCity: '',
-      inputAddress: '',
-      TimePicker: '',
-      UpdatePhoto: '',
-      ReplyMessage: '',
+      title: '',
+      content: '',
+      food: {
+        name: '',
+        type: '',
+        saveMethod: '',
+        totalQuantity: '',
+        expiryDate: '',
+        isPastBestBefore: '',
+        dietType: '',
+      },
+      pickup: {
+        city: '',
+        district: '',
+        time: '',
+        address: '',
+      },
+      imagesUrl: [],
     },
     mode: 'onTouched',
   });
@@ -89,6 +92,7 @@ const ShareFoodModal = () => {
                       errors={errors}
                       labelText="貼文標題"
                       id="InputTitle"
+                      name="title"
                       type="text"
                       rules={{
                         required: {
@@ -103,6 +107,7 @@ const ShareFoodModal = () => {
                       errors={errors}
                       labelText="食物名稱"
                       id="InputFood"
+                      name="food.name"
                       type="text"
                       rules={{
                         required: {
@@ -128,6 +133,7 @@ const ShareFoodModal = () => {
                             errors={errors}
                             labelText="食物類型"
                             id="FoodType"
+                            name="food.type"
                             apiEndpoint="/foodTypes"
                             optionLabelKey="type"
                             optionValueKey="value"
@@ -147,7 +153,7 @@ const ShareFoodModal = () => {
                         <div className="share-food-modal d-lg-flex">
                           <div className="me-lg-7 mb-2">
                             <label
-                              htmlFor="FoodType"
+                              htmlFor="SaveMethod"
                               className="form-label h6 fw-bold text-gray-700 col-lg-1 text-nowrap py-4"
                             >
                               保存方式
@@ -158,6 +164,7 @@ const ShareFoodModal = () => {
                             errors={errors}
                             labelText="保存方式"
                             id="SaveMethod"
+                            name="food.saveMethod"
                             apiEndpoint="/saveMethod"
                             optionLabelKey="type"
                             optionValueKey="value"
@@ -188,6 +195,7 @@ const ShareFoodModal = () => {
                             errors={errors}
                             labelText="食物份數"
                             id="FoodNum"
+                            name="food.totalQuantity"
                             type="number"
                             rules={{
                               required: {
@@ -219,7 +227,7 @@ const ShareFoodModal = () => {
                             id="exp"
                             selected={startDate}
                             onChange={(date) => setStartDate(date)}
-                            name="exp"
+                            name="food.expiryDate"
                             dateFormat="yyyy/MM/dd"
                             className="form-select border-gray-400 py-2 px-5 rounded-3 bg-white"
                             placeholderText="請選擇有效期限"
@@ -235,6 +243,7 @@ const ShareFoodModal = () => {
                         errors={errors}
                         labelText="是否已過期"
                         id="overfood"
+                        name="food.isPastBestBefore"
                         options={overfoodOptions}
                         rules={{
                           required: { value: true, message: '請至少選擇一項' },
@@ -248,6 +257,7 @@ const ShareFoodModal = () => {
                         errors={errors}
                         labelText="葷食/素食"
                         id="MeatOrVeggie"
+                        name="food.dietType"
                         options={meatOrVeggieOptions}
                         rules={{
                           required: { value: true, message: '請至少選擇一項' },
@@ -268,6 +278,8 @@ const ShareFoodModal = () => {
                         errors={errors}
                         cityId="city"
                         districtId="district"
+                        cityName="pickup.city"
+                        districtName="pickup.city"
                         rules={{
                           required: {
                             value: true,
@@ -279,6 +291,7 @@ const ShareFoodModal = () => {
                         register={register}
                         errors={errors}
                         id="inputAddress"
+                        name="pickup.address"
                         labelText="地址"
                         rules={{
                           required: {
@@ -308,11 +321,19 @@ const ShareFoodModal = () => {
                       >
                         上傳圖片
                       </label>
-                      <input
-                        type="file"
-                        className="form-control bg-white py-2 px-5 border-gray-400 rounded-3"
+                      <InputText
+                        register={register}
+                        errors={errors}
+                        labelText="圖片網址，https://images.unsplash.com/photo-15689013"
                         id="UpdatePhoto"
-                        placeholder="請輸入食物名稱"
+                        name="imagesUrl"
+                        type="text"
+                        rules={{
+                          required: {
+                            value: true,
+                            message: '請輸入圖片網址',
+                          },
+                        }}
                       />
                     </div>
                     <div className="share-food-modal mb-7 d-flex flex-column flex-lg-row gap-2">
@@ -327,7 +348,14 @@ const ShareFoodModal = () => {
                         errors={errors}
                         labelText="介紹與描述"
                         id="ReplyMessage"
+                        name="content"
                         rows="5"
+                        rules={{
+                          required: {
+                            value: true,
+                            message: '請輸入食物介紹',
+                          },
+                        }}
                       />
                     </div>
                   </div>

--- a/src/components/ShareFoodModal.jsx
+++ b/src/components/ShareFoodModal.jsx
@@ -50,10 +50,11 @@ const ShareFoodModal = () => {
   } = methods;
 
   const onSubmit = async (data) => {
-    const { food, expiryDate, ...rest } = data;
+    const { food, expiryDate, imagesUrl, ...rest } = data;
     const { ...submitData } = food;
     const formattedExpiryDate = dayjs(expiryDate).format('YYYY-MM-DD');
     const createdPostDate = dayjs().format('YYYY-MM-DD HH:mm:ss');
+    const imagesUrlArray = imagesUrl ? [imagesUrl] : [];
 
     try {
       const post = await axios.post(`${BASE_URL}/posts`, {
@@ -66,6 +67,7 @@ const ShareFoodModal = () => {
           ...data.pickup,
         },
         createdPostDate,
+        imagesUrl: imagesUrlArray,
       });
       alert('表單已送出');
     } catch (error) {

--- a/src/components/ShareFoodModal.jsx
+++ b/src/components/ShareFoodModal.jsx
@@ -24,7 +24,7 @@ const ShareFoodModal = () => {
         name: '',
         type: '',
         saveMethod: '',
-        totalQuantity: '',
+        totalQuantity: 0,
         expiryDate: '',
         isPastBestBefore: '',
         dietType: '',
@@ -36,6 +36,7 @@ const ShareFoodModal = () => {
         address: '',
       },
       imagesUrl: [],
+      userId: '1',
     },
     mode: 'onTouched',
   });

--- a/src/components/account/AccountNav.jsx
+++ b/src/components/account/AccountNav.jsx
@@ -11,12 +11,12 @@ function AccountNav() {
           <ul className="navbar-nav d-lg-flex d-none justify-content-between mb-14">
             <li
               className={`nav-item ${
-                location.pathname.endsWith('/account') ? 'active' : ''
+                location.pathname.endsWith('/setting') ? 'active' : ''
               }`}
             >
               <NavLink
                 className="d-flex align-items-center px-5 py-6 gap-5 fw-bold"
-                to="/account"
+                to="/account/setting"
               >
                 <svg
                   width="16"

--- a/src/components/account/DeletePostModal.jsx
+++ b/src/components/account/DeletePostModal.jsx
@@ -1,0 +1,58 @@
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
+const DeletePostModal = () => {
+  const deletePost = async () => {
+    try {
+      const res = await axios.delete(`${BASE_URL}/posts/`);
+      alert('貼文刪除成功');
+      window.location.reload();
+    } catch (error) {
+      console.log(error.message);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="modal fade"
+        id="deletePostModal"
+        tabIndex="-1"
+        aria-labelledby="deletePostModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h1 className="modal-title fs-5" id="deletePostModal">
+                刪除貼文
+              </h1>
+            </div>
+            <div className="modal-body text-danger py-10">
+              確認刪除此篇貼文？
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-white"
+                onClick={deletePost}
+              >
+                確認刪除貼文
+              </button>
+              <button
+                type="button"
+                className="btn btn-dark fw-bold h6"
+                data-bs-dismiss="modal"
+              >
+                取消
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default DeletePostModal;

--- a/src/components/formElements/CityDistrictSelector.jsx
+++ b/src/components/formElements/CityDistrictSelector.jsx
@@ -12,6 +12,8 @@ function CityDistrictSelector({
   rules,
   initialCityId,
   initialDistrict,
+  cityName,
+  districtName,
 }) {
   const [cities, setCities] = useState([]);
   const [districts, setDistricts] = useState([]);

--- a/src/components/formElements/InputText.jsx
+++ b/src/components/formElements/InputText.jsx
@@ -1,3 +1,5 @@
+import { get } from 'lodash';
+
 const InputText = ({ register, errors, id, labelText, rules, name, type }) => {
   return (
     <div className="w-100">
@@ -6,13 +8,13 @@ const InputText = ({ register, errors, id, labelText, rules, name, type }) => {
         id={id}
         name={name}
         className={`form-control py-2 px-5 border-gray-400 rounded-3 bg-white lh-account ${
-          errors?.[id] && 'is-invalid'
+          get(errors, name) && 'is-invalid'
         }`}
         placeholder={`請輸入${labelText}`}
-        {...register(id, rules)}
+        {...register(name, rules)}
       />
-      {errors[id] && (
-        <div className="invalid-feedback">{errors?.[id]?.message}</div>
+      {get(errors, name) && (
+        <div className="invalid-feedback">{get(errors, name)?.message}</div>
       )}
     </div>
   );

--- a/src/components/formElements/InputTextGroup.jsx
+++ b/src/components/formElements/InputTextGroup.jsx
@@ -1,6 +1,14 @@
 import InputText from './InputText';
 
-const InputTextGroup = ({ register, errors, labelText, id, type, rules }) => {
+const InputTextGroup = ({
+  register,
+  errors,
+  labelText,
+  id,
+  type,
+  rules,
+  name,
+}) => {
   return (
     <>
       <div className="share-food-modal mb-7 d-flex flex-column flex-lg-row gap-2">
@@ -14,6 +22,7 @@ const InputTextGroup = ({ register, errors, labelText, id, type, rules }) => {
           register={register}
           errors={errors}
           id={id}
+          name={name}
           labelText={labelText}
           rules={rules}
           type={type}

--- a/src/components/formElements/RadioGroup.jsx
+++ b/src/components/formElements/RadioGroup.jsx
@@ -1,4 +1,14 @@
-const RadioGroup = ({ register, errors, labelText, id, rules, options }) => {
+import { get } from 'lodash';
+
+const RadioGroup = ({
+  register,
+  errors,
+  labelText,
+  id,
+  rules,
+  options,
+  name,
+}) => {
   return (
     <div className="mb-7">
       <div className="share-food-modal d-lg-flex align-items-lg-center">
@@ -16,17 +26,21 @@ const RadioGroup = ({ register, errors, labelText, id, rules, options }) => {
             className="form-check ms-0 align-items-center ms-lg-7"
           >
             <input
-              className={`form-check-input ${errors[id] && 'is-invalid'}`}
+              className={`form-check-input ${
+                get(errors, name) && 'is-invalid'
+              }`}
               type="radio"
               id={item.id}
               value={item.value}
-              {...register(id, rules)}
+              {...register(name, rules)}
             />
             <label className="form-check-label text-nowrap" htmlFor={item.id}>
               {item.label}
             </label>
-            {errors[id] && (
-              <div className="invalid-feedback">{errors?.[id]?.message}</div>
+            {get(errors, name) && (
+              <div className="invalid-feedback">
+                {get(errors, name)?.message}
+              </div>
             )}
           </div>
         ))}

--- a/src/components/formElements/SelectBox.jsx
+++ b/src/components/formElements/SelectBox.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
+import { get } from 'lodash';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
@@ -12,6 +13,7 @@ const SelectBox = ({
   apiEndpoint,
   optionLabelKey,
   optionValueKey,
+  name,
 }) => {
   const [options, setOptions] = useState([]);
 
@@ -32,11 +34,11 @@ const SelectBox = ({
       <div className="flex-grow-1 ms-lg-7">
         <select
           id={id}
-          name={id}
+          name={name}
           className={`form-select border-gray-400 py-2 px-5 rounded-3 bg-white ${
-            errors?.[id] && 'is-invalid'
+            get(errors, name) && 'is-invalid'
           }`}
-          {...register(id, rules)}
+          {...register(name, rules)}
         >
           <option value="" disabled selected>
             請選擇{labelText}
@@ -47,8 +49,8 @@ const SelectBox = ({
             </option>
           ))}
         </select>
-        {errors[id] && (
-          <div className="invalid-feedback">{errors?.[id]?.message}</div>
+        {get(errors, name) && (
+          <div className="invalid-feedback">{get(errors, name)?.message}</div>
         )}
       </div>
     </>

--- a/src/components/formElements/TextArea.jsx
+++ b/src/components/formElements/TextArea.jsx
@@ -1,13 +1,23 @@
-const TextArea = ({ register, errors, labelText, id, rows, name }) => {
+import { get } from 'lodash';
+
+const TextArea = ({ register, errors, labelText, id, rows, name, rules }) => {
   return (
-    <textarea
-      id={id}
-      name={name}
-      rows={rows}
-      placeholder={`請輸入${labelText}`}
-      className="form-control py-2 px-5 border-gray-400 rounded-3 bg-white"
-      {...register(id)}
-    ></textarea>
+    <>
+      <textarea
+        id={id}
+        name={name}
+        rows={rows}
+        placeholder={`請輸入${labelText}`}
+        className={`form-control py-2 px-5 border-gray-400 rounded-3 bg-white w-100 ${
+          get(errors, name) && 'is-invalid'
+        }`}
+        {...register(name, rules)}
+      >
+        {get(errors, name) && (
+          <div className="invalid-feedback">{get(errors, name)?.message}</div>
+        )}
+      </textarea>
+    </>
   );
 };
 

--- a/src/layouts/Header.jsx
+++ b/src/layouts/Header.jsx
@@ -180,7 +180,7 @@ const Header = () => {
     if (e.key === 'Enter') {
       handleSearch(e);
     }
-  }
+  };
 
   const toggleOffcanvas = () => {
     if (isOffcanvasOpen) {
@@ -189,14 +189,14 @@ const Header = () => {
       setSelectedFoodType('美食類型');
     }
     setIsOffcanvasOpen(!isOffcanvasOpen);
-  }
- 
+  };
+
   // 處理搜尋結果，將搜尋條件帶到 all-posts 頁面
   const handleSearch = (e) => {
     e.preventDefault();
 
     const searchParams = new URLSearchParams();
-    
+
     if (searchInput.trim()) {
       searchParams.append('keyword', searchInput.trim());
     }
@@ -209,9 +209,9 @@ const Header = () => {
       searchParams.append('foodType', selectedFoodType);
     }
 
-    navigate(`/all-posts?${searchParams.toString()}`)
+    navigate(`/all-posts?${searchParams.toString()}`);
 
-    if(isSearchVisible) {
+    if (isSearchVisible) {
       toggleSearch();
     }
 
@@ -383,7 +383,7 @@ const Header = () => {
                     >
                       <li>
                         <NavLink
-                          to="/account"
+                          to="/account/setting"
                           className="dropdown-item"
                         >
                           個人設定
@@ -398,7 +398,10 @@ const Header = () => {
                         </NavLink>
                       </li>
                       <li>
-                        <NavLink to="/account/my-posts" className="dropdown-item">
+                        <NavLink
+                          to="/account/my-posts"
+                          className="dropdown-item"
+                        >
                           我的發文
                         </NavLink>
                       </li>

--- a/src/pages/account/AccountPosts.jsx
+++ b/src/pages/account/AccountPosts.jsx
@@ -3,6 +3,8 @@ import AccountFilter from '../../components/account/AccountFilter';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import { Link } from 'react-router';
+import ShareFoodModal from '../../components/ShareFoodModal';
+import DeletePostModal from '../../components/account/DeletePostModal';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 const ID = '1';
@@ -250,17 +252,29 @@ function AccountPosts() {
                           </a>
                           <ul className="dropdown-menu">
                             <li>
-                              <a className="dropdown-item" href="#">
+                              <a
+                                className="dropdown-item"
+                                href="#"
+                                data-bs-toggle="modal"
+                                data-bs-target="#shareFoodModal"
+                              >
                                 編輯貼文
                               </a>
                             </li>
                             <li>
-                              <a className="dropdown-item" href="#">
+                              <a
+                                className="dropdown-item"
+                                href="#"
+                                data-bs-toggle="modal"
+                                data-bs-target="#deletePostModal"
+                              >
                                 刪除貼文
                               </a>
                             </li>
                           </ul>
                         </div>
+                        <ShareFoodModal />
+                        <DeletePostModal />
                         {/* dropdown */}
                         <div className="post-card-img my-7 text-center">
                           <Link

--- a/src/pages/section/AccountSettingForm.jsx
+++ b/src/pages/section/AccountSettingForm.jsx
@@ -7,7 +7,7 @@ import ChangePhotoModal from '../../components/account/ChangePhotoModal';
 import logo from '/assets/images/Logo.png';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
-const USER_ID = '2';
+const USER_ID = '1';
 
 function AccountSettingForm() {
   // const [cities, setCities] = useState([]);

--- a/src/pages/section/AccountSettingModalPassword.jsx
+++ b/src/pages/section/AccountSettingModalPassword.jsx
@@ -77,7 +77,7 @@ function AccountSettingModalPassword() {
               >
                 取消
               </button>
-              <button type="button" className="btn btn-primary">
+              <button type="button" className="btn btn-dark fw-bold h6">
                 變更
               </button>
             </div>


### PR DESCRIPTION
# 請說明這個 PR 主要的用途：
在 Account 頁面的 nav 個人設定沒有點選也會有 active 標籤，
調整路由使其改為非預設

## 本次 PR 調整的細節請用條列說明：
1. 調整 accountSetting 的路徑
```diff
   element: <Account />,
    children: [
      {
-       index: true,
+       path: 'setting',
        element: <AccountSetting />,
      }
    ]
``` 
2. 有將 Header.jsx 路徑一起調整 
```diff
 <li>
  <NavLink
-    to="/account"
+    to="/account/setting"
    className="dropdown-item"
  >
    個人設定
  </NavLink>
</li>
```

## 有可能發生的問題：
1. 無

---
## 最後送出 PR 前，請先自我檢查以下是否已完成：
- [x] 查看 base branch 是否有正確
- [x] 這支 PR 是否有明確的標題、內容描述